### PR TITLE
Add failing test u16_little_endian_pack_and_unpack_with_offset

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,6 +47,15 @@ fn u16_pack_with_offset() {
 }
 
 #[test]
+fn u16_little_endian_pack_and_unpack_with_offset() {
+    let mut data = [0u8; 8];
+    let value = 0x123;
+    value.pack_le_bits(&mut data, 11, 13);
+    let unpacked_value = u16::unpack_le_bits(&mut data, 11, 13);
+    assert_eq!(value, unpacked_value);
+}
+
+#[test]
 fn u16_little_endian_pack_and_unpack() {
     let mut data = [0u8; 2];
     let value = 0x1234;


### PR DESCRIPTION
I think the issue might be somewhere [here](https://github.com/bitbleep/bitsh/blob/master/src/lib.rs#L63).
But I haven't figured it out yet.

```
---- tests::u16_little_endian_pack_and_unpack_with_offset stdout ----
[0, 18, 9, 0, 0, 0, 0, 0]
thread 'tests::u16_little_endian_pack_and_unpack_with_offset' panicked at 'attempt to shift left with overflow', src/lib.rs:64:21
```