### PR TITLE
Add property based tests for u16 packing and unpacking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["Martin <martin@bitbleep.com>"]
 edition = "2018"
 
 [dependencies]
+
+[dev-dependencies]
+proptest = "1"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use proptest::{prelude::ProptestConfig, prop_assert_eq, proptest};
 
 // todo: not sure about this
 // #[test]
@@ -64,6 +65,23 @@ fn u16_little_endian_pack_and_unpack() {
     assert_eq!(value, unpacked_value);
 }
 
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 10000,  .. ProptestConfig::default()
+      })]
+    #[test]
+    fn u16_little_endian_pack_and_unpack_proptest(value in (0..65535u16), start_bit in (0..15usize)) {
+        let mut data : [u8; 2]= [0, 0];
+        // bits required to store value
+        let num_bits = ((value as f32).log2() + 1.0) as usize;
+        let start_bit = if start_bit + num_bits > 16 { 16 - num_bits } else { start_bit };
+
+        value.pack_le_bits(&mut data, start_bit, num_bits);
+        let unpacked_value = u16::unpack_le_bits(&data, start_bit, num_bits);
+        prop_assert_eq!(value, unpacked_value)
+    }
+}
+
 #[test]
 fn u16_big_endian_pack_and_unpack() {
     let mut data = [0u8; 2];
@@ -71,6 +89,23 @@ fn u16_big_endian_pack_and_unpack() {
     value.pack_be_bits(&mut data, 0, 16);
     let unpacked_value = u16::unpack_be_bits(&data, 0, 16);
     assert_eq!(value, unpacked_value);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 10000, .. ProptestConfig::default()
+      })]
+    #[test]
+    fn u16_big_endian_pack_and_unpack_proptest(value in (0..65535u16), start_bit in (0..15usize)) {
+        let mut data : [u8; 2]= [0, 0];
+        // bits required to store value
+        let num_bits = ((value as f32).log2() + 1.0) as usize;
+        let start_bit = if start_bit + num_bits > 16 { 16 - num_bits } else { start_bit };
+
+        value.pack_be_bits(&mut data, start_bit, num_bits);
+        let unpacked_value = u16::unpack_be_bits(&data, start_bit, num_bits);
+        prop_assert_eq!(value, unpacked_value)
+    }
 }
 
 #[test]


### PR DESCRIPTION
Had some issues with big endian packing and unpacking and thought it properly would be good to have more test cases for more confidence. Running the `u16_little_endian_pack_and_unpack_proptest` looks good. `u16_big_endian_pack_and_unpack_proptest` though e.g. currently fails:

```
thread 'tests::u16_big_endian_pack_and_unpack_proptest' panicked at 'Test failed: assertion failed: `(left == right)` 
  left: `1`,
 right: `0` at src/tests.rs:107; minimal failing input: value = 1, start_bit = 0
```

Will also attempt to find out how to fix this.